### PR TITLE
Adding support for prerender token, fixing compatibility with later versions of prerender

### DIFF
--- a/Demo/Web.config
+++ b/Demo/Web.config
@@ -14,7 +14,8 @@
   </connectionStrings>
   <prerender
     prerenderServiceUrl="http://localhost:3000"
-    crawlerUserAgents="me,you,she,he">
+    crawlerUserAgents="me,you,she,he"
+    token="[YOUR_TOKEN_HERE]">
   </prerender>
   
   <appSettings>

--- a/Prerender_asp_mvc/PrerenderConfigSection.cs
+++ b/Prerender_asp_mvc/PrerenderConfigSection.cs
@@ -6,13 +6,13 @@ namespace Prerender_asp_mvc
 {
     public sealed class PrerenderConfigSection : ConfigurationSection
     {
-        [ConfigurationProperty("prerenderServiceUrl", DefaultValue = "http://prerender.herokuapp.com/")]
+        [ConfigurationProperty("prerenderServiceUrl", DefaultValue = "http://service.prerender.io/")]
         public String PrerenderServiceUrl
         {
             get
             {
                 var prerenderServiceUrl = (String)this["prerenderServiceUrl"];
-                return prerenderServiceUrl.IsNotBlank() ? prerenderServiceUrl : "http://prerender.herokuapp.com/";
+                return prerenderServiceUrl.IsNotBlank() ? prerenderServiceUrl : "http://service.prerender.io/";
             }
             set
             {
@@ -115,6 +115,19 @@ namespace Prerender_asp_mvc
             set
             {
                 this["Proxy"] = value;
+            }
+        }
+
+        [ConfigurationProperty("token")]
+        public String Token
+        {
+            get
+            {
+                return (String)this["token"];
+            }
+            set
+            {
+                this["token"] = value;
             }
         }
     }

--- a/Prerender_asp_mvc/Properties/AssemblyInfo.cs
+++ b/Prerender_asp_mvc/Properties/AssemblyInfo.cs
@@ -2,9 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// 有关程序集的常规信息通过以下
-// 特性集控制。更改这些特性值可修改
-// 与程序集关联的信息。
 [assembly: AssemblyTitle("Prerender_asp_mvc")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
@@ -14,23 +11,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// 将 ComVisible 设置为 false 使此程序集中的类型
-// 对 COM 组件不可见。如果需要从 COM 访问此程序集中的类型，
-// 则将该类型上的 ComVisible 特性设置为 true。
 [assembly: ComVisible(false)]
 
-// 如果此项目向 COM 公开，则下列 GUID 用于类型库的 ID
 [assembly: Guid("fee09175-4250-430a-bef0-96eb1f5165ea")]
 
-// 程序集的版本信息由下面四个值组成:
-//
-//      主版本
-//      次版本 
-//      生成号
-//      修订号
-//
-// 可以指定所有这些值，也可以使用“生成号”和“修订号”的默认值，
-// 方法是按如下所示使用“*”:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Prerender_asp_mvc/ResponseResult.cs
+++ b/Prerender_asp_mvc/ResponseResult.cs
@@ -17,10 +17,17 @@ namespace Prerender_asp_mvc
             get;
         }
 
-        public ResponseResult(HttpStatusCode code, String body)
+        public WebHeaderCollection Headers
+        {
+            private set; 
+            get; 
+        }
+
+        public ResponseResult(HttpStatusCode code, String body, WebHeaderCollection headers)
         {
             StatusCode = code;
             ResponseBody = body;
+            Headers = headers;
         }
 
     }


### PR DESCRIPTION
Adding support for prerender token, fixing compatibility with later versions of prerender so the status code (and headers) returned from prerender service are correctly put onto the response back to the crawler, and the pipeline is terminated. Also improved crawler detection by using contains rather than exact case insensitive match. Finally, added support for AWS load balancers with use X-Forwarded-Proto headers
