### PR TITLE
Add ability to ignore all subdomains.

### DIFF
--- a/Prerender.io/PrerenderConfigSection.cs
+++ b/Prerender.io/PrerenderConfigSection.cs
@@ -88,6 +88,19 @@ namespace Prerender.io
             }
         }
 
+        [ConfigurationProperty("ignoreAllSubdomains")]
+        public bool IgnoreAllSubdomains
+        {
+            get
+            {
+                return (bool)this["ignoreAllSubdomains"];
+            }
+            set
+            {
+                this["ignoreAllSubdomains"] = value;
+            }
+        }
+
         public IEnumerable<String> ExtensionsToIgnore
         {
             get

--- a/Prerender.io/PrerenderModule.cs
+++ b/Prerender.io/PrerenderModule.cs
@@ -166,6 +166,10 @@ namespace Prerender.io
                 return false;
             }
 
+            if (IgnoreAllSubdomains(url))
+            {
+                return false;
+            }
 
             if (IsInResources(url))
             {
@@ -219,6 +223,21 @@ namespace Prerender.io
                 extensionsToIgnore.AddRange(_prerenderConfig.ExtensionsToIgnore);
             }
             return extensionsToIgnore;
+        }
+        private bool IgnoreAllSubdomains(Uri url)
+        {
+            if (_prerenderConfig.IgnoreAllSubdomains)
+            {
+                char[] separators = new char[] { '.' };
+                string hostname = url.Host;
+                string[] domains = hostname.Split(separators);
+                string subdomain = domains[0];
+                if (!String.IsNullOrEmpty(subdomain))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private bool IsInSearchUserAgent(string useAgent)


### PR DESCRIPTION
This adds the ability to ignore all subdomains using a web config setting.  If ignoreAllSubdomains is set to true, it will check the URL for a subdomain.  If it contains a subdomain, it wont be prerendered.  This functionality is necessary for sites with many subdomains. 