### PR TITLE
Extendend list of CrawlerUserAgents

### DIFF
--- a/Prerender.io/PrerenderModule.cs
+++ b/Prerender.io/PrerenderModule.cs
@@ -247,7 +247,7 @@ namespace Prerender.io
                     "embedly", "quora link preview", "showyoubot", "outbrain", "pinterest/0.", 
                     "developers.google.com/+/web/snippet", "slackbot", "vkShare", "W3C_Validator", 
                     "redditbot", "Applebot", "WhatsApp", "flipboard", "tumblr", "bitlybot", 
-                    "SkypeUriPreview", "nuzzel", "Discordbot", "Google Page Speed", "yandex", "bufferbot"
+                    "SkypeUriPreview", "nuzzel", "Discordbot", "Google Page Speed", "x-bufferbot"
                 });
 
             if (_prerenderConfig.CrawlerUserAgents.IsNotEmpty())

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Demo project moved to [Prerender_asp_mvc_demo](https://github.com/greengerong/Pr
 	<httpModules>
 		<add name="Prerender" type="Prerender.io.PrerenderModule, Prerender.io, Version=1.0.0.2, Culture=neutral, PublicKeyToken=null"/>
 	</httpModules>
-   
+
 
 *** register
-   
+
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -29,19 +29,19 @@ Demo project moved to [Prerender_asp_mvc_demo](https://github.com/greengerong/Pr
     using Microsoft.Web.Infrastructure.DynamicModuleHelper;
     using Microsoft.Web.WebPages.OAuth;
     using Demo.Models;
-    
+
     namespace Demo
     {
         public static class PreApplicationStartCode
         {
             private static bool _isStarting;
-    
+
             public static void PreStart()
             {
                 if (!_isStarting)
                 {
                     _isStarting = true;
-    
+
                     DynamicModuleUtility.RegisterModule(typeof(Prerender.io.PrerenderModule));
                 }
             }
@@ -50,8 +50,8 @@ Demo project moved to [Prerender_asp_mvc_demo](https://github.com/greengerong/Pr
 
     on AssemblyInfo.cs :
     [assembly: PreApplicationStartMethod(typeof(Demo.PreApplicationStartCode), "PreStart")]
-    
-you can see [PreApplicationStartCode](https://github.com/greengerong/Prerender_asp_mvc/blob/master/Demo/App_Start/PreApplicationStartCode.cs)
+
+you can see [PreApplicationStartCode](https://github.com/greengerong/Prerender_asp_mvc_demo/blob/master/App_Start/PreApplicationStartCode.cs)
 
 #### Please see demo on this repo.
 
@@ -65,8 +65,8 @@ you can see [PreApplicationStartCode](https://github.com/greengerong/Prerender_a
 2. Make a `GET` request to the [prerender service](https://github.com/collectiveip/prerender)(phantomjs server) for the page's prerendered HTML
 3. Return that HTML to the crawler
 
-## Customization 
- 
+## Customization
+
  you can add config on your web.config by Prerender.io.PrerenderConfigSection.
 
 ### crawlerUserAgents


### PR DESCRIPTION
I have extended the list of CrawlerUserAgents of this ASP.NET middleware using the more comprehensive list found in Node.js's middleware [https://github.com/prerender/prerender-node/blob/master/index.js#L40](https://github.com/prerender/prerender-node/blob/master/index.js#L40) as a reference.  I have left "yandex" and "bufferbot" which are currently missing in the Node.js version.

Also note that in the Node.js  list "bingbot" was commented out, Todd @ Prerender.io explained how Google, Bing, and Yandex follow the escaped fragment crawling protocol and recommends to add in the `<head>` :

`<meta name="fragment" content="!">`

as per [https://developers.google.com/webmasters/ajax-crawling/docs/specification](https://developers.google.com/webmasters/ajax-crawling/docs/specification) which albeit Google now deprecates it, it is still fully supported.