### PR TITLE
Added Googlebot, bingbot, and yandex to list of user agents

### DIFF
--- a/Prerender.io/PrerenderModule.cs
+++ b/Prerender.io/PrerenderModule.cs
@@ -262,13 +262,7 @@ namespace Prerender.io
         {
             var crawlerUserAgents = new List<string>(new[]
                 {
-                    // googlebot, yahoo, and bingbot are not in this list because
-                    // we support _escaped_fragment_ and want to ensure people aren't
-                    // penalized for cloaking.
-                    // "googlebot", 
-                    // "yahoo", 
-                    // "bingbot",
-                    "baiduspider", "facebookexternalhit", "twitterbot", "rogerbot", "linkedinbot", 
+                    "googlebot", "yahoo", "bingbot", "yandex", "baiduspider", "facebookexternalhit", "twitterbot", "rogerbot", "linkedinbot", 
                     "embedly", "quora link preview", "showyoubot", "outbrain", "pinterest/0.", 
                     "developers.google.com/+/web/snippet", "slackbot", "vkShare", "W3C_Validator", 
                     "redditbot", "Applebot", "WhatsApp", "flipboard", "tumblr", "bitlybot", 


### PR DESCRIPTION
Googlebot announced "Dynamic Rendering" where you can now serve pages to Googlebot by checking their user agent directly.

We've also confirmed through Bing support that you can do the same for Bing.

Find more information about Google's Dynamic Rendering support here: https://prerender.io/documentation/google-support

@greengerong could you please merge this? Thanks!